### PR TITLE
fix: remove prerender flag from sitemap route

### DIFF
--- a/src/pages/sitemap.xml.ts
+++ b/src/pages/sitemap.xml.ts
@@ -1,8 +1,6 @@
 import type { APIRoute } from "astro";
 import { getVolumes, getMetadata } from "../lib/db";
 
-export const prerender = true;
-
 interface SitemapUrl {
   loc: string;
   lastmod: string;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated sitemap generation configuration to use default rendering settings instead of explicit prerender directive, simplifying configuration management and aligning with system defaults while maintaining proper sitemap functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->