### PR TITLE
feat: add opt-in two-page (spread) reader view

### DIFF
--- a/src/components/ChapterNavigation.astro
+++ b/src/components/ChapterNavigation.astro
@@ -2,6 +2,8 @@
 import "../styles/global.css";
 import ArrowIcon from "./ArrowIcon.astro";
 import ThemeToggle from "./ThemeToggle.astro";
+import ViewToggle from "./ViewToggle.astro";
+import DirectionToggle from "./DirectionToggle.astro";
 
 export interface Props {
   volume: number;
@@ -95,6 +97,8 @@ const { volume, chapter, prevChapter, nextChapter } = Astro.props;
           </button>
         )
       }
+      <DirectionToggle />
+      <ViewToggle />
       <ThemeToggle />
     </div>
   </div>

--- a/src/components/DirectionToggle.astro
+++ b/src/components/DirectionToggle.astro
@@ -1,0 +1,45 @@
+---
+
+---
+
+<button
+  type="button"
+  id="directionToggle"
+  aria-label="Toggle reading direction"
+  aria-pressed="false"
+  class="hidden md:inline-flex items-center justify-center w-10 h-10 rounded-lg text-black hover:bg-gray-100 dark:text-neutral-200 dark:hover:bg-neutral-900 focus:outline-none focus:ring-2 focus:ring-gray-300 dark:focus:ring-neutral-700 transition-colors"
+>
+  <i
+    id="directionIcon"
+    class="fas fa-arrow-right-arrow-left inline text-2xl"
+    aria-hidden="true"></i>
+</button>
+
+<script>
+  const button = document.getElementById("directionToggle");
+
+  if (button) {
+    const sync = (isLtr: boolean) => {
+      // aria-pressed reflects the non-default (left-to-right) direction.
+      button.setAttribute("aria-pressed", isLtr ? "true" : "false");
+      button.setAttribute(
+        "aria-label",
+        isLtr
+          ? "Reading left-to-right (switch to right-to-left)"
+          : "Reading right-to-left (switch to left-to-right)",
+      );
+    };
+
+    sync(document.documentElement.classList.contains("ltr"));
+
+    button.addEventListener("click", () => {
+      const isLtr = document.documentElement.classList.toggle("ltr");
+
+      sync(isLtr);
+
+      try {
+        localStorage.setItem("readingDirection", isLtr ? "ltr" : "rtl");
+      } catch (e) {}
+    });
+  }
+</script>

--- a/src/components/PageViewer.astro
+++ b/src/components/PageViewer.astro
@@ -1,9 +1,17 @@
 ---
+import { computeSpreads } from "../feature/reader/spreads";
+
 export interface Props {
   pagesUrl: string[];
 }
 
 const { pagesUrl } = Astro.props;
+
+// Group pages into spreads for the two-page view. Each <img> keeps its true
+// global page index (for data-page and the eager/lazy rule); the wrappers are
+// transparent (display:contents) in single mode, so the layout is identical to
+// a flat list until the `double` class is toggled on <html>. See spreads.ts.
+const spreads = computeSpreads(pagesUrl.length);
 ---
 
 <div
@@ -11,14 +19,18 @@ const { pagesUrl } = Astro.props;
 >
   <div class="w-full max-w-350 flex flex-col items-center">
     {
-      pagesUrl.map((pageUrl, index) => (
-        <img
-          src={pageUrl}
-          alt={`Page ${index + 1}`}
-          class="h-auto max-h-screen block mb-0.5 object-contain border border-gray-900 dark:border-neutral-700"
-          loading={index < 3 ? "eager" : "lazy"}
-          data-page={index}
-        />
+      spreads.map((group, spreadIndex) => (
+        <div class="spread" data-spread data-spread-index={spreadIndex}>
+          {group.map((pageIndex) => (
+            <img
+              src={pagesUrl[pageIndex]}
+              alt={`Page ${pageIndex + 1}`}
+              class="h-auto max-h-screen block mb-0.5 object-contain border border-gray-900 dark:border-neutral-700"
+              loading={pageIndex < 3 ? "eager" : "lazy"}
+              data-page={pageIndex}
+            />
+          ))}
+        </div>
       ))
     }
   </div>

--- a/src/components/ViewToggle.astro
+++ b/src/components/ViewToggle.astro
@@ -1,0 +1,39 @@
+---
+
+---
+
+<button
+  type="button"
+  id="viewToggle"
+  aria-label="Toggle two-page view"
+  aria-pressed="false"
+  class="hidden md:inline-flex items-center justify-center w-10 h-10 rounded-lg text-black hover:bg-gray-100 dark:text-neutral-200 dark:hover:bg-neutral-900 focus:outline-none focus:ring-2 focus:ring-gray-300 dark:focus:ring-neutral-700 transition-colors"
+>
+  <i id="viewIcon" class="fas fa-file inline text-2xl" aria-hidden="true"></i>
+</button>
+
+<script>
+  const button = document.getElementById("viewToggle");
+  const icon = document.getElementById("viewIcon");
+
+  if (button && icon) {
+    const sync = (isDouble: boolean) => {
+      icon.className = isDouble
+        ? "fas fa-book-open inline text-2xl"
+        : "fas fa-file inline text-2xl";
+      button.setAttribute("aria-pressed", isDouble ? "true" : "false");
+    };
+
+    sync(document.documentElement.classList.contains("double"));
+
+    button.addEventListener("click", () => {
+      const isDouble = document.documentElement.classList.toggle("double");
+
+      sync(isDouble);
+
+      try {
+        localStorage.setItem("viewMode", isDouble ? "double" : "single");
+      } catch (e) {}
+    });
+  }
+</script>

--- a/src/feature/reader/spreads.ts
+++ b/src/feature/reader/spreads.ts
@@ -1,0 +1,29 @@
+// Pairing logic for the two-page (spread) view. Shared by the build-time
+// chunking in PageViewer.astro and the keyboard stepping in ChapterLayout.astro
+// so the two can never disagree on how pages are grouped.
+//
+// offset=1 => page 1 (index 0) stands alone, then pairs: [[0],[1,2],[3,4],...]
+// This mirrors how a physical volume opens on a single page and gives interior
+// double-page splash art the best chance of landing together on one facing row.
+export function computeSpreads(pageCount: number, offset = 1): number[][] {
+  const spreads: number[][] = [];
+  let i = 0;
+
+  if (offset === 1 && pageCount > 0) {
+    spreads.push([0]);
+    i = 1;
+  }
+
+  for (; i < pageCount; i += 2) {
+    spreads.push(i + 1 < pageCount ? [i, i + 1] : [i]);
+  }
+
+  return spreads;
+}
+
+export const spreadIndexOfPage = (
+  spreads: number[][],
+  page: number,
+): number => spreads.findIndex((group) => group.includes(page));
+
+export const leadingPageOfSpread = (group: number[]): number => group[0];

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -49,6 +49,19 @@ const title = tagline
         if (meta) meta.setAttribute("content", isDark ? "#000000" : "#ffffff");
       } catch (e) {}
     </script>
+    <script is:inline>
+      // Apply the reader view-mode preferences before first paint to avoid a
+      // single->double layout flash (mirrors the theme script above).
+      try {
+        if (
+          localStorage.getItem("viewMode") === "double" &&
+          window.matchMedia("(min-width:768px)").matches
+        )
+          document.documentElement.classList.add("double");
+        if (localStorage.getItem("readingDirection") === "ltr")
+          document.documentElement.classList.add("ltr");
+      } catch (e) {}
+    </script>
     <slot name="head" />
     <script
       is:inline

--- a/src/layouts/ChapterLayout.astro
+++ b/src/layouts/ChapterLayout.astro
@@ -46,8 +46,14 @@ const { volume, chapter, prevChapter, nextChapter } = Astro.props;
     currentPage,
     isProgrammaticScroll,
   } from "../feature/reader/store";
+  import {
+    computeSpreads,
+    spreadIndexOfPage,
+    leadingPageOfSpread,
+  } from "../feature/reader/spreads";
   const viewer = document.querySelector("[data-page-count]") as HTMLElement;
   const pageCount = Number(viewer.dataset.pageCount);
+  const spreads = computeSpreads(pageCount);
 
   let lastScrollTop = 0;
   let hideTimeout: number;
@@ -80,14 +86,37 @@ const { volume, chapter, prevChapter, nextChapter } = Astro.props;
     let pageIndex;
     let currentPageIndex = currentPage.get();
 
+    // In two-page view, step by a whole spread instead of a single page.
+    // Paired images share the same offsetTop, so a per-page step would leave
+    // every other press with no visible scroll. Branch on the live DOM class
+    // so this is correct immediately after a mid-read toggle.
+    const isDouble =
+      document.documentElement.classList.contains("double") &&
+      window.matchMedia("(min-width:768px)").matches;
+
+    let step;
     if (event.key === "ArrowUp" || event.key === "ArrowLeft") {
       event.preventDefault();
-      pageIndex = Math.max(0, currentPageIndex - 1);
+      step = -1;
     } else if (event.key === "ArrowDown" || event.key === "ArrowRight") {
       event.preventDefault();
-      pageIndex = Math.min(pageCount - 1, currentPageIndex + 1);
+      step = 1;
     } else {
       return;
+    }
+
+    if (isDouble) {
+      const currentSpread = spreadIndexOfPage(spreads, currentPageIndex);
+      const targetSpread = Math.min(
+        spreads.length - 1,
+        Math.max(0, currentSpread + step),
+      );
+      pageIndex = leadingPageOfSpread(spreads[targetSpread]);
+    } else {
+      pageIndex = Math.min(
+        pageCount - 1,
+        Math.max(0, currentPageIndex + step),
+      );
     }
 
     if (pageIndex !== currentPageIndex) {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -6,6 +6,39 @@
 
 @custom-variant dark (&:where(.dark, .dark *));
 
+/* Two-page (spread) view — opt-in, desktop only.
+   Single mode: the wrapper is transparent to layout, so images cascade
+   exactly as a flat list (identical to the original single-page reader). */
+.spread {
+  display: contents;
+}
+
+/* The reading-direction toggle only matters in double mode. */
+html:not(.double) #directionToggle {
+  display: none;
+}
+
+@media (min-width: 768px) {
+  html.double .spread {
+    display: flex;
+    flex-direction: row-reverse; /* RTL default: earlier page on the RIGHT */
+    align-items: flex-start;
+    justify-content: center;
+    gap: 0.125rem;
+    margin-bottom: 0.125rem;
+    width: 100%;
+  }
+
+  html.double.ltr .spread {
+    flex-direction: row; /* LTR: earlier page on the left */
+  }
+
+  html.double .spread > img {
+    max-width: 50%;
+    margin-bottom: 0;
+  }
+}
+
 .animate-gradient {
   background: linear-gradient(
     270deg,


### PR DESCRIPTION
## Summary

Adds an opt-in **two-page (spread) view** to the reader: a toggle that pairs consecutive pages into side-by-side facing spreads like a physical volume, plus a **reading-direction toggle** (right-to-left by default, matching Vagabond's native order). Single-page stays the default, so existing readers see no change.

## How it works

- **`src/feature/reader/spreads.ts`** (new) — pairing helper: page 1 alone, then `[2,3], [4,5]…`. Single source of truth for both build-time chunking and keyboard nav.
- **`PageViewer.astro`** — wraps images in `.spread` groups. Each `<img>` keeps its original classes and true global `data-page` index, so the scroll observer, progress bar, and page counter are **reused untouched**.
- **`global.css`** — `.spread { display: contents }` makes single mode layout-identical to today; `@media (min-width:768px) html.double` flips to a `flex-row-reverse` spread (RTL), with `html.double.ltr` for left-to-right.
- **`ViewToggle.astro` / `DirectionToggle.astro`** (new) — toggle `double` / `ltr` classes on `<html>`, persist to `localStorage`, cloned from the theme-toggle pattern. Hidden below the `md` breakpoint.
- **`ChapterNavigation.astro`** — mounts both toggles next to `ThemeToggle`.
- **`BaseLayout.astro`** — `is:inline` pre-paint script applies the saved classes before first paint (no flash), gated by `matchMedia` so phones never get tiny spreads.
- **`ChapterLayout.astro`** — arrow keys step one full spread at a time in double mode.

Two-page view is **desktop-only** (>=768px); preference persists in `localStorage`.

## Testing

- `pnpm build` succeeds (361 pages). Inspected generated `dist/volume-1/chapter-1/index.html`: 24 spreads with correct pairing (`[1]`, `[2,3]`, `[4,5]…`, clean trailing singleton), eager-loading on the first 3 images, all toggles present, pre-paint script inlined, compiled CSS contains the spread rules.

## Known minor behaviors

- In double mode the page counter reports the **later** page of the on-screen pair (last-write-wins in the existing scroll observer); progress still advances monotonically to 100%.
- Pairing is a metadata-free heuristic (page 1 alone), so a true double-page splash on the other parity could straddle two rows. The `offset` arg in `computeSpreads` is the escape hatch.
- Paired pages are top-aligned; differing heights leave a ragged bottom edge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added desktop reading controls for reading direction and single- or two-page viewing.
  * Reader preferences are remembered between visits.
  * Two-page view displays facing pages together and supports spread-based keyboard navigation.
  * Reading direction can be switched for compatible layouts.

* **Style**
  * Added responsive styling for two-page spreads and direction-aware page ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->