### PR TITLE
feat: add end-of-chapter navigation bar

### DIFF
--- a/db/queries.ts
+++ b/db/queries.ts
@@ -174,6 +174,22 @@ export const getMangaChapterByNumber = async (
   return data[0];
 };
 
+export const getChapterNavByNumber = async (
+  db: Database,
+  chapterNumber: number,
+) => {
+  const data = await db
+    .select({
+      number: chaptersTable.number,
+      title: chaptersTable.title,
+      volume: volumesTable.number,
+    })
+    .from(chaptersTable)
+    .innerJoin(volumesTable, eq(volumesTable.id, chaptersTable.volumeId))
+    .where(eq(chaptersTable.number, chapterNumber));
+  return data[0];
+};
+
 export const getMangaChaptersByMangaId = async (
   db: Database,
   mangaId: number,

--- a/src/components/ChapterEndNavigation.astro
+++ b/src/components/ChapterEndNavigation.astro
@@ -1,0 +1,91 @@
+---
+import ArrowIcon from "./ArrowIcon.astro";
+
+export interface ChapterLink {
+  number: number;
+  title: string;
+  volume: number;
+}
+
+export interface Props {
+  volume: number;
+  prev: ChapterLink | null;
+  next: ChapterLink | null;
+}
+
+const { volume, prev, next } = Astro.props;
+---
+
+<nav
+  aria-label="Chapter navigation"
+  class="w-full border-t border-gray-200 dark:border-neutral-800 bg-white dark:bg-black"
+>
+  <div
+    class="max-w-350 mx-auto px-4 py-6 md:py-8 flex items-stretch justify-between gap-3 md:gap-4"
+  >
+    {
+      prev !== null ? (
+        <a
+          href={`/volume-${prev.volume}/chapter-${prev.number}`}
+          class="group flex-1 flex flex-col gap-1 text-gray-900 dark:text-white bg-white dark:bg-neutral-950 border border-gray-300 dark:border-neutral-700 hover:bg-gray-100 dark:hover:bg-neutral-900 focus:ring-4 focus:ring-gray-100 dark:focus:ring-neutral-800 rounded-lg px-4 py-3 focus:outline-none transition-colors"
+        >
+          <span class="inline-flex items-center gap-1.5 text-[11px] md:text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-neutral-400">
+            <ArrowIcon direction="left" class="w-3 h-3" />
+            Previous
+          </span>
+          <span class="text-xs md:text-sm font-semibold truncate">
+            Ch. {prev.number} — {prev.title}
+          </span>
+        </a>
+      ) : (
+        <div
+          class="flex-1 flex flex-col gap-1 text-gray-400 dark:text-neutral-600 bg-gray-100 dark:bg-neutral-900 border border-gray-200 dark:border-neutral-800 rounded-lg px-4 py-3 cursor-not-allowed"
+          aria-disabled="true"
+        >
+          <span class="inline-flex items-center gap-1.5 text-[11px] md:text-xs font-medium uppercase tracking-wide">
+            <ArrowIcon direction="left" class="w-3 h-3" />
+            Previous
+          </span>
+          <span class="text-xs md:text-sm font-semibold">Start of Vagabond</span>
+        </div>
+      )
+    }
+
+    <a
+      href={`/volume-${volume}`}
+      class="hidden sm:flex items-center justify-center text-gray-500 dark:text-neutral-400 hover:text-gray-900 dark:hover:text-white text-[11px] md:text-sm font-medium uppercase tracking-wide whitespace-nowrap px-2 focus:outline-none focus:ring-4 focus:ring-gray-100 dark:focus:ring-neutral-800 rounded-lg transition-colors"
+    >
+      Volume {volume}
+    </a>
+
+    {
+      next !== null ? (
+        <a
+          href={`/volume-${next.volume}/chapter-${next.number}`}
+          class="group flex-1 flex flex-col gap-1 items-end text-right text-white dark:text-black bg-black dark:bg-white hover:bg-neutral-900 dark:hover:bg-neutral-200 focus:ring-4 focus:ring-gray-300 dark:focus:ring-neutral-700 rounded-lg px-4 py-3 focus:outline-none transition-colors"
+        >
+          <span class="inline-flex items-center gap-1.5 text-[11px] md:text-xs font-medium uppercase tracking-wide opacity-80">
+            {next.volume !== volume ? "Next Volume" : "Next"}
+            <ArrowIcon direction="right" class="w-3 h-3" />
+          </span>
+          <span class="text-xs md:text-sm font-semibold truncate w-full">
+            Ch. {next.number} — {next.title}
+          </span>
+        </a>
+      ) : (
+        <div
+          class="flex-1 flex flex-col gap-1 items-end text-right text-gray-400 dark:text-neutral-600 bg-gray-100 dark:bg-neutral-900 border border-gray-200 dark:border-neutral-800 rounded-lg px-4 py-3 cursor-not-allowed"
+          aria-disabled="true"
+        >
+          <span class="inline-flex items-center gap-1.5 text-[11px] md:text-xs font-medium uppercase tracking-wide">
+            Next
+            <ArrowIcon direction="right" class="w-3 h-3" />
+          </span>
+          <span class="text-xs md:text-sm font-semibold">
+            You've reached the end
+          </span>
+        </div>
+      )
+    }
+  </div>
+</nav>

--- a/src/layouts/ChapterLayout.astro
+++ b/src/layouts/ChapterLayout.astro
@@ -4,6 +4,8 @@ import ChapterNavigation from "../components/ChapterNavigation.astro";
 import ProgressBar from "../components/ProgressBar.astro";
 import PageViewer from "../components/PageViewer.astro";
 import ArrowKeysHint from "../components/ArrowKeysHint.astro";
+import ChapterEndNavigation from "../components/ChapterEndNavigation.astro";
+import type { ChapterLink } from "../components/ChapterEndNavigation.astro";
 import type { Props as BaseLayoutProps } from "./BaseLayout.astro";
 
 export interface Props extends BaseLayoutProps {
@@ -15,9 +17,12 @@ export interface Props extends BaseLayoutProps {
   };
   prevChapter: number | null;
   nextChapter: number | null;
+  prevNav: ChapterLink | null;
+  nextNav: ChapterLink | null;
 }
 
-const { volume, chapter, prevChapter, nextChapter } = Astro.props;
+const { volume, chapter, prevChapter, nextChapter, prevNav, nextNav } =
+  Astro.props;
 ---
 
 <BaseLayout {...Astro.props}>
@@ -36,6 +41,7 @@ const { volume, chapter, prevChapter, nextChapter } = Astro.props;
 
   <main data-page-count={chapter.pagesUrl.length}>
     <PageViewer pagesUrl={chapter.pagesUrl} />
+    <ChapterEndNavigation volume={volume} prev={prevNav} next={nextNav} />
     <ArrowKeysHint />
   </main>
 </BaseLayout>

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -36,3 +36,7 @@ export async function getMangaChapterById(chapterId: number) {
 export async function getMangaChapterByNumber(chapterNumber: number) {
   return queries.getMangaChapterByNumber(db, chapterNumber);
 }
+
+export async function getChapterNavByNumber(chapterNumber: number) {
+  return queries.getChapterNavByNumber(db, chapterNumber);
+}

--- a/src/pages/volume-[volume]/chapter-[chapter]/index.astro
+++ b/src/pages/volume-[volume]/chapter-[chapter]/index.astro
@@ -4,6 +4,7 @@ import ChapterLayout from "../../../layouts/ChapterLayout.astro";
 import {
   getMangaVolumeByNumber,
   getMangaChapterByNumber,
+  getChapterNavByNumber,
   getMangaVolumes,
 } from "../../../lib/db";
 import { buildPageUrl } from "../../../lib/page";
@@ -59,6 +60,13 @@ if (chapter.number > lastChapter || chapter.number < firstChapter) {
 const prevChapter = chapter.number > firstChapter ? chapter.number - 1 : null;
 const nextChapter = chapter.number < lastChapter ? chapter.number + 1 : null;
 
+// Cross-volume links for the end-of-chapter navigation bar. Chapters are
+// numbered contiguously across the whole series, so the neighbours are simply
+// number ± 1; the lookup resolves each to its volume (and returns undefined at
+// the very first/last chapter, which renders as a start/end state).
+const prevNav = (await getChapterNavByNumber(chapter.number - 1)) ?? null;
+const nextNav = (await getChapterNavByNumber(chapter.number + 1)) ?? null;
+
 const pagesUrl = Array.from({ length: chapter.pageCount }, (_, i) =>
   buildPageUrl({
     volume: volume.number,
@@ -90,4 +98,6 @@ const pagesUrl = Array.from({ length: chapter.pageCount }, (_, i) =>
   }}
   prevChapter={prevChapter}
   nextChapter={nextChapter}
+  prevNav={prevNav}
+  nextNav={nextNav}
 />


### PR DESCRIPTION
## Summary

Adds a navigation bar after the last page of every chapter so readers can move to the next chapter without scrolling back up to the top nav.

Layout: **Previous Chapter** (left) · **Volume link** (center) · **Next Chapter** (right).

## Key behavior: continuous reading across volumes

The existing top nav's prev/next is bounded *within the current volume* (it dead-ends at each volume's first/last chapter). This bottom bar instead **continues across volume boundaries** — the last chapter of a volume links straight to the first chapter of the next (labelled **"Next Volume"**), so you can read the whole series end to end.

Boundary states verified in the built output:
| Chapter | Previous | Next |
|---|---|---|
| ch.5 (mid-volume) | ch.4 | ch.6 |
| ch.10 (vol 1 end) | ch.9 | **ch.11 (vol 2)** — "Next Volume" |
| ch.11 (vol 2 start) | **ch.10 (vol 1)** | ch.12 |
| ch.1 (series start) | disabled — "Start of Vagabond" | ch.2 |
| ch.322 (series end) | ch.321 | disabled — "You've reached the end" |

## How it works

- **`getChapterNavByNumber`** (new query in `db/queries.ts` + wrapper in `src/lib/db.ts`) resolves a chapter number to `{ number, title, volume }`. Chapters are numbered contiguously across the series, so a chapter's neighbours are simply `number ± 1`; a missing result marks the series start/end.
- **`ChapterEndNavigation.astro`** (new) renders the bar. Reuses `ArrowIcon` and mirrors the top nav's button styling (solid black/white "next", outlined "prev", disabled state for boundaries). The center volume link collapses on very small screens.
- Wired into the chapter page (`volume-[volume]/chapter-[chapter]/index.astro`) and `ChapterLayout.astro`, rendered after `PageViewer`. The top nav's within-volume prev/next is left untouched.

## Testing

- `astro build` succeeds (361 pages); inspected generated HTML for all five boundary cases above.
- Verified live in `astro dev` (HTTP 200, bar present).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added end-of-chapter navigation with Previous, Next, and Volume links.
  * Navigation now works seamlessly across volume boundaries.
  * Added clear disabled states at the beginning and end of the series.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->